### PR TITLE
Updates to test cases for Labs 2, 3, and 6

### DIFF
--- a/labs/2.advanced-routing/README.md
+++ b/labs/2.advanced-routing/README.md
@@ -175,6 +175,34 @@ URI: /coffee
 Request ID: 0f5cd7a2f62965279c4bdc52c660c97d
 ```
 
+Access `coffee-v3` using a query string
+```code
+curl --resolve cafe.example.com:$HTTP_PORT:$NGF_IP http://cafe.example.com:$HTTP_PORT/coffee?queryRegex=query-a
+```
+
+Output should be similar to
+```code
+Server address: 192.168.169.141:8080
+Server name: coffee-v3-7fb98466f-tgq8k
+Date: 18/Sep/2025:21:26:26 +0000
+URI: /coffee?queryRegex=query-a
+Request ID: 2c755a8391ebd2df87f416510fb5478b
+```
+
+Access `coffee-v3` using an HTTP header
+```code
+curl --resolve cafe.example.com:$HTTP_PORT:$NGF_IP http://cafe.example.com:$HTTP_PORT/coffee -H "headerRegex: header-a"
+```
+
+Output should be similar to
+```code
+Server address: 192.168.169.141:8080
+Server name: coffee-v3-7fb98466f-tgq8k
+Date: 18/Sep/2025:21:25:13 +0000
+URI: /coffee
+Request ID: 81431954b4b52edc01d707b4e5822792
+```
+
 Access `tea` using `GET`
 ```code
 curl --resolve cafe.example.com:$HTTP_PORT:$NGF_IP http://cafe.example.com:$HTTP_PORT/tea

--- a/labs/3.http-headers/2.httproute.yaml
+++ b/labs/3.http-headers/2.httproute.yaml
@@ -39,3 +39,10 @@ spec:
     backendRefs:
     - name: headers
       port: 80
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /nofilter
+    backendRefs:
+    - name: headers
+      port: 80

--- a/labs/3.http-headers/README.md
+++ b/labs/3.http-headers/README.md
@@ -105,9 +105,45 @@ echo -e "NGF address: $NGF_IP\nHTTP port  : $HTTP_PORT"
 
 Access the test application
 ```code
-curl -i --resolve echo.example.com:$HTTP_PORT:$NGF_IP http://echo.example.com:$HTTP_PORT/headers -H "My-Cool-Header:my-client-value" -H "My-Overwrite-Header:dont-see-this" 
+curl -i --resolve echo.example.com:$HTTP_PORT:$NGF_IP http://echo.example.com:$HTTP_PORT/nofilter -H "My-Cool-Header:my-client-value" -H "My-Overwrite-Header:dont-see-this" 
+```
+Output should be similar to
+```code
+HTTP/1.1 200 OK
+Server: nginx
+Date: Thu, 18 Sep 2025 21:42:45 GMT
+Content-Type: text/plain
+Content-Length: 450
+Connection: keep-alive
+
+Headers:
+  header 'Host' is 'echo.example.com:30177'
+  header 'X-Forwarded-For' is '10.1.1.8'
+  header 'X-Real-IP' is '10.1.1.8'
+  header 'X-Forwarded-Proto' is 'http'
+  header 'X-Forwarded-Host' is 'echo.example.com'
+  header 'X-Forwarded-Port' is '80'
+  header 'Connection' is 'close'
+  header 'User-Agent' is 'curl/7.81.0'
+  header 'Accept' is '*/*'
+  header 'My-Cool-Header' is 'my-client-value'
+  header 'My-Overwrite-Header' is 'dont-see-this'
 ```
 
+Request headers of note:
+
+- User-Agent header is present.
+- The header My-Cool-header has its single my-client-value value.
+- The header My-Overwrite-Header has its single dont-see-this value.
+- Accept-encoding header is not present.
+
+Response Headers `X-Header-Set` and `X-Header-Add` are not present.
+
+
+Access the test application via filters route
+```code
+curl -i --resolve echo.example.com:$HTTP_PORT:$NGF_IP http://echo.example.com:$HTTP_PORT/headers -H "My-Cool-Header:my-client-value" -H "My-Overwrite-Header:dont-see-this" 
+```
 
 Output should be similar to
 ```code

--- a/labs/6.grpc/README.md
+++ b/labs/6.grpc/README.md
@@ -117,7 +117,7 @@ Output should be
 ```
 
 Remove the exact method matching gRPC route
-C```code
+```code
 kubectl delete -f 1.grpcroute-exactmethod.yaml
 ```
 
@@ -224,6 +224,63 @@ Output should be similar to
 2025/06/12 11:28:02 server listening at [::]:50051
 2025/06/12 11:40:13 Received: bar server
 2025/06/12 11:42:12 Received: version two
+```
+
+Test the application sending a request with HTTP header `regexHeader: grpc-header-a`
+```code
+grpcurl -plaintext -proto grpc.proto -authority bar.com -d '{"name": "grpc-header-a"}' -H 'grpcRegex: grpc-header-a' ${NGF_IP}:${HTTP_PORT} helloworld.Greeter/SayHello
+```
+
+The request has been routed to pod `grpc-infra-backend-2`
+```code
+kubectl logs -l app=grpc-infra-backend-v2
+```
+
+Output should be similar to
+```code
+2025/09/18 22:24:44 server listening at [::]:50051
+2025/09/18 22:28:45 Received: bar server
+2025/09/18 22:29:53 Received: version two
+2025/09/18 22:34:08 Received: grpc-header-a
+```
+
+Test the application sending a request with HTTP header `color: blue`
+```code
+grpcurl -plaintext -proto grpc.proto -authority bar.com -d '{"name": "blue 1"}' -H 'color: blue' ${NGF_IP}:${HTTP_PORT} helloworld.Greeter/SayHello
+```
+
+The request has been routed to pod `grpc-infra-backend-v1`
+```code
+kubectl logs -l app=grpc-infra-backend-v1
+```
+
+Output should be similar to
+```code
+2025/09/18 22:24:44 server listening at [::]:50051
+2025/09/18 22:26:22 Received: exact
+2025/09/18 22:27:34 Received: bar server
+2025/09/18 22:30:09 Received: version one
+2025/09/18 22:35:22 Received: blue 1
+```
+
+
+Test the application sending a request with HTTP header `color: red`
+```code
+grpcurl -plaintext -proto grpc.proto -authority bar.com -d '{"name": "red 2"}' -H 'color: red' ${NGF_IP}:${HTTP_PORT} helloworld.Greeter/SayHello
+```
+
+The request has been routed to pod `grpc-infra-backend-v2`
+```code
+kubectl logs -l app=grpc-infra-backend-v2
+```
+
+Output should be similar to
+```code
+2025/09/18 22:24:44 server listening at [::]:50051
+2025/09/18 22:28:45 Received: bar server
+2025/09/18 22:29:53 Received: version two
+2025/09/18 22:34:08 Received: grpc-header-a
+2025/09/18 22:36:03 Received: red 2
 ```
 
 Delete the lab


### PR DESCRIPTION
Lab 2 - added missing test cases for coffee-v3
Lab 3 - added nofilter route and test cases to help comparison with headers filtered route
Lab 6 - corrected malformed code tag in README and added missing test cases for gRPC header routing